### PR TITLE
fastlane: add DE locale and improve formatting for full descriptions

### DIFF
--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,0 +1,26 @@
+<i>AstraCrypt</i> - ist eine leistungsstarke Verschlüsselungs-App, die alles hat, was Sie brauchen, um Ihre Daten sicher und geschützt aufzubewahren.</p>
+
+Möchten Sie Daten verbergen? Möchten Sie die Verschlüsselungsalgorithmen maximal nutzen? Diese App vereint all das! Und das Beste: Sie ist sehr einfach zu bedienen.</p>
+
+Diese App verwendet die Authentifizierte Verschlüsselung mit zusätzlichen Datenalgorithmen (einschließlich AES256/GCM), um Ihre Dateien zu schützen und sicherzustellen, dass nur Sie darauf zugreifen können. Diese Verschlüsselung wird auf einer Vielzahl von Geräten und Anwendungen verwendet und gilt als eine der sichersten verfügbaren Verschlüsselungsmethoden.</p>
+
+Mit einer intuitiven und modernen Materialdesign-Oberfläche macht es <i>AstraCrypt</i> einfacher als je zuvor, Ihre Daten zu verschlüsseln.</p>
+
+<i>AstraCrypt</i> hat auch viele zusätzliche Funktionen. Beispielsweise können Sie die Authentifizierung aktivieren, um Ihren Dateien eine zusätzliche Schutzebene hinzuzufügen.</p>
+
+Über das Lab-Menü können Sie verschiedene verfügbare Algorithmen verwenden, um verschlüsselte Daten auf einem externen Speichergerät zu speichern oder umgekehrt (ohne sie mit den Gerätedaten zu verknüpfen).</p>
+
+Die Anwendung ermöglicht es Benutzern auch, Notizen und andere Arten von Daten sicher zu speichern, und bietet den Benutzern gleichzeitig eine intuitive und benutzerfreundliche Benutzeroberfläche. Alle Daten, die im verschlüsselten Container gespeichert sind, der vollständig verschlüsselt und sicher ist, wodurch sichergestellt wird, dass alle sensiblen Dateien oder Daten, die in der Anwendung gespeichert sind, sicher und geschützt bleiben.</p>
+
+<br>Wir wissen, wie wichtig es ist, Ihre Daten sicher zu halten, deshalb bietet <i>AstraCrypt</i> all diese Funktionen in einem Paket. Mit <i>AstraCrypt</i> können Sie sicher sein, dass Ihre Dateien verschlüsselt und vor neugierigen Blicken geschützt sind.</p>
+
+Laden Sie es jetzt herunter, um Ihre Dateien zu schützen und sicher aufzubewahren!</p>
+
+<b>Hauptprogrammmerkmale:</b>
+
+* 10+ Verschlüsselungsalgorithmen.
+* Mehrfachverschlüsselung von Benutzerdaten.
+* Geräteverwaltungsfunktionen.
+* Hochgradig anpassbare Sicherheitseinstellungen.
+* Modernes Material, das Sie entwerfen.
+* Grundlegende Dateisystemstruktur und -funktionen.

--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+Verstecken und verschlüsseln Sie Ihre Dateien mit modernen Sicherheitsstandards

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,14 +1,23 @@
-AstraCrypt - is a powerful encryption app that has everything you need to keep your data safe and secure. 
+AstraCrypt - is a powerful encryption app that has everything you need to keep your data safe and secure.
+
 Want to hide data? Want to use the encryption algorithms to the maximum? This app combines all of that! And the best part: it's very simple to use.
+
 This app utilizes the Authenticated Encryption with Additional Data algorithms (including AES256/GCM) to protect your files, ensuring that only you have access to them. This encryption is used on a wide range of devices and applications, and is considered one of the most secure encryption methods available.
+
 With an intuitive and modern Material Design interface, AstraCrypt makes it easier than ever to encrypt your data.
+
 AstraCrypt also has many additional features. For example, you can enable  authentication to add an extra layer of protection to your files.
+
 Using the Lab menu, you can use different available algorithms to save encrypted data to an external storage device or vice versa (without linking it to the device data).
+
 The application also allows users to store notes and other types of data in a secure manner, while also providing users with an intuitive and easy-to-use user interface. All data stored in the encrypted container which is fully encrypted and secure, ensuring that any sensitive file or data stored in the application remains safe and secure.
 
 We know how important it is to keep your data secure, so AstraCrypt offers all these features in one package. With AstraCrypt, you can rest assured that your files are encrypted and safe from prying eyes.
+
 Download now to protect your files and keep them safe!
-Main program features:
+
+<b>Main program features:</b>
+
 ✦ 10+ encryption algorithms.
 ✦ Multi-encryption of user data.
 ✦ Device admin features.


### PR DESCRIPTION
This PR slightly improves formatting of the English full description, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds the German (de) locale with short and full description.